### PR TITLE
changed info to allow for ios geolocation

### DIFF
--- a/MobileApp/MobileApp.iOS/Info.plist
+++ b/MobileApp/MobileApp.iOS/Info.plist
@@ -39,5 +39,7 @@
 	</array>
 	<key>CFBundleShortVersionString</key>
 	<string>0.1.0</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>Needs location to track found places</string>
 </dict>
 </plist>


### PR DESCRIPTION
### Summary (what did you accomplish?)
This pr changes info.plist to allow for ios geolocation permissions

### Purpose
ios app wont function without it

## What changes did you make?
- [x] Example: Changed info.plist to include NSLocationWhenInUseUsageDescription

# What is your plan for testing? Have you executed any of it?
* Already tested, makes ios functional
