### PR TITLE
Fixed merge conflict markers

### DIFF
--- a/Backend/Backend.csproj
+++ b/Backend/Backend.csproj
@@ -6,14 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-<<<<<<< HEAD
-    <None Remove="Admin\client\src\components\Login.tsx" />
-=======
     <Compile Remove="Admin\client\**" />
     <Content Remove="Admin\client\**" />
     <EmbeddedResource Remove="Admin\client\**" />
     <None Remove="Admin\client\**" />
->>>>>>> MoreProduction
   </ItemGroup>
 
   <ItemGroup>
@@ -50,9 +46,6 @@
   </ItemGroup>
 
   <ItemGroup>
-<<<<<<< HEAD
-    <TypeScriptCompile Include="Admin\client\src\components\Login.tsx" />
-=======
     <Content Update="client\build\asset-manifest.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
@@ -95,7 +88,6 @@
     <None Update="client\build\static\js\runtime-main.2d0c9ef4.js">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
->>>>>>> MoreProduction
   </ItemGroup>
 
 </Project>

--- a/Backend/Startup.cs
+++ b/Backend/Startup.cs
@@ -67,11 +67,7 @@ namespace Backend
 
             app.UseSpa(spa =>
             {
-<<<<<<< HEAD
                 spa.Options.SourcePath = Path.Join(env.ContentRootPath, "client/build");
-=======
-                //spa.Options.SourcePath = Path.Join(env.ContentRootPath, "client/build");
->>>>>>> MoreProduction
 
                 /*if (env.IsDevelopment())
                 {

--- a/BackendModel/BackendModel.csproj
+++ b/BackendModel/BackendModel.csproj
@@ -5,6 +5,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="Migrations\**" />
+    <EmbeddedResource Remove="Migrations\**" />
+    <None Remove="Migrations\**" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.5" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="5.0.5">
       <PrivateAssets>all</PrivateAssets>
@@ -32,10 +38,6 @@
       <AutoGen>True</AutoGen>
       <DependentUpon>CornellGoDb.tt</DependentUpon>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Folder Include="Migrations\" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
### Summary (what did you accomplish?)
Example: This pr changes the model in BackendModel to account for the new group state. These changes have been integrated fully into the backend.

### Purpose
Example: The old group model did not account for the maximum possible number of members in a team, but this pr accomplishes that.

## What changes did you make?
- [x] Example: Changed GroupExtensions.cs to include new functionality for updating group state.
- [x] Example: Changed GroupHub.cs to allow frontend to access this new group state.

## What improvements can be made? Is the anything left to do?
- [ ] Example: Add more documentation to GroupExtensions.cs
- [ ] Example: Make public API cleaner

## Any breaking changes or new dependencies?
* Example: Added a reference to Newtonsoft.Json in NuGet.
* Example: Frontend cannot accept the old API and will crash if it tries, needs to be rewired. Remove old API step by step.
* Example: Create a new method in IClientHub interface and created default implementation. Might cause merge conflict and needs to be implemented.

# What is your plan for testing? Have you executed any of it?
* Example: Make sure that the new group functionality is implemented correctly.
* Example: Check with frontend team that these changes are correct and the API exposes enough functionality.
