### PR TITLE
Fixed non-notification of groupmate readiness.

### DIFF
--- a/Backend/Hub/GroupHub.cs
+++ b/Backend/Hub/GroupHub.cs
@@ -209,6 +209,9 @@ namespace Backend.Hub
                 user.GroupMember.IsDone = true;
                 await Clients.Caller.FinishChallenge();
 
+                await Clients.Group(user.GroupMember.Group.SignalRId).UpdateGroupMember(
+                    new (user.Id.ToString(), user.Username, user.GroupMember.IsHost, true, user.Score));
+
                 //Add to sessionlog
                 var entry = new SessionLogEntry(SessionLogEntryType.FoundPlace, user.GroupMember.Group.Id.ToString(), DateTime.UtcNow, user);
                 await Database.SessionLogEntries.AddAsync(entry);

--- a/MobileApp/MobileApp/ViewModels/GameViewModel.cs
+++ b/MobileApp/MobileApp/ViewModels/GameViewModel.cs
@@ -170,13 +170,22 @@ namespace MobileApp.ViewModels
                 IsHost = data.IsHost, IsReady = data.IsDone, Username = data.Username, Score = data.Points
             };
 
-            await Device.InvokeOnMainThreadAsync(() => GroupMembers[index] = newMember);
+            await Device.InvokeOnMainThreadAsync(() => 
+            { 
+                GroupMembers[index] = newMember;
+                UpdateGroupDataFromList();
+            });
         }
 
         private async Task Client_GroupMemberLeft(string userId)
         {
             int index = GetGroupMemberIndex(userId);
-            await Device.InvokeOnMainThreadAsync(() => GroupMembers.RemoveAt(index));
+            await Device.InvokeOnMainThreadAsync(() =>
+            {
+                GroupMembers.RemoveAt(index);
+                UpdateGroupDataFromList();
+            });
+            UpdateGroupDataFromList();
         }
 
         private async Task Client_GroupDataUpdated(string friendlyId, CommunicationModel.GroupMemberData[] members)


### PR DESCRIPTION
### Summary (what did you accomplish?)
Example: This pr changes the model in BackendModel to account for the new group state. These changes have been integrated fully into the backend.

### Purpose
Example: The old group model did not account for the maximum possible number of members in a team, but this pr accomplishes that.

## What changes did you make?
- [x] Example: Changed GroupExtensions.cs to include new functionality for updating group state.
- [x] Example: Changed GroupHub.cs to allow frontend to access this new group state.

## What improvements can be made? Is the anything left to do?
- [ ] Example: Add more documentation to GroupExtensions.cs
- [ ] Example: Make public API cleaner

## Any breaking changes or new dependencies?
* Example: Added a reference to Newtonsoft.Json in NuGet.
* Example: Frontend cannot accept the old API and will crash if it tries, needs to be rewired. Remove old API step by step.
* Example: Create a new method in IClientHub interface and created default implementation. Might cause merge conflict and needs to be implemented.

# What is your plan for testing? Have you executed any of it?
* Example: Make sure that the new group functionality is implemented correctly.
* Example: Check with frontend team that these changes are correct and the API exposes enough functionality.
